### PR TITLE
Fix for handing unloaded relationships

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -46,7 +46,8 @@ function currentState(model, field) {
   let config = Ember.get(model.constructor, 'relationshipsByName').get(field);
   if (config.kind === 'hasMany') {
     let reference = model.hasMany(field);
-    return reference.value().toArray();
+    let value = reference.value();
+    return value ? value.toArray() : null;
   } else {
     let reference = model.belongsTo(field);
     return reference.value();

--- a/tests/integration/mixins/track-relationships-test.js
+++ b/tests/integration/mixins/track-relationships-test.js
@@ -206,3 +206,15 @@ test('can roll back hasMany to previous value', function(assert) {
     assert.deepEqual(pc.map(c => c.get('body')), ["first post"]);
   });
 });
+
+test('can handle hasMany with an unsaved parent record', function(assert) {
+  let unsavedPost;
+  Ember.run(() => {
+    unsavedPost = this.store.createRecord('post');
+    unsavedPost.watchRelationship('pendingComments', () => {
+      let newComment = this.store.createRecord('comment', { body: 'other' });
+      unsavedPost.get('pendingComments').pushObject(newComment);
+    });
+  });
+  assert.equal(unsavedPost.get('hasDirtyFields'), true);
+});


### PR DESCRIPTION
`relationship.value()` returns `null` when the relationship is not loaded so we need to account for this case.

I tested by hand in an actual app and it works there, but I was unable to reproduce a failing test case.