### PR TITLE
Fix for propertyDidChange deprecation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -17,7 +17,7 @@ export default Ember.Mixin.create({
       entry[changed] = currentState(this, field);
     }
     fn();
-    this.propertyDidChange('hasDirtyRelationships');
+    this.notifyPropertyChange('hasDirtyRelationships');
   },
 
   hasDirtyRelationships: Ember.computed('changed', function() {
@@ -37,7 +37,7 @@ export default Ember.Mixin.create({
       if (!tracker[field] || !(changed in tracker[field])) { return; }
       this.set(field, tracker[field][changed]);
     });
-    this.propertyDidChange('hasDirtyRelationships');
+    this.notifyPropertyChange('hasDirtyRelationships');
   }
 
 });


### PR DESCRIPTION
Fix for the below deprecation
```
 Log: |
            { type: 'warn',
              text: '\'DEPRECATION: \\\'propertyDidChange\\\' is deprecated in favor of 
\\\'notifyPropertyChange\\\'. It is safe to change this call to \\\'notifyPropertyChange\\\'. [deprecation id: 
ember-metal.deprecate-propertyDidChange] See https://emberjs.com/deprecations/v3.x/#toc_use-
notifypropertychange-instead-of-propertywillchange-and-propertydidchange for more details.\\n        at 
logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:36658:21)\\n        at HANDLERS.
(anonymous function) (http://localhost:7357/assets/vendor.js:36886:9)\\n        at raiseOnDeprecation 
(http://localhost:7357/assets/vendor.js:36688:14)\\n        at HANDLERS.(anonymous function) 
(http://localhost:7357/assets/vendor.js:36886:9)\\n        at invoke 
(http://localhost:7357/assets/vendor.js:36898:9)\\n        at Object.deprecate 
(http://localhost:7357/assets/vendor.js:36752:24)\\n        at propertyDidChange 
(http://localhost:7357/assets/vendor.js:47257:34)\\n        at Class.propertyDidChange 
(http://localhost:7357/assets/vendor.js:61224:41)\\n        at Class.watchRelationship 
(http://localhost:7357/assets/vendor.js:185052:12)\'\n' }

```