### PR TITLE
pass args to super

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -5,7 +5,7 @@ import isEqual from 'lodash-es/isEqual';
 
 export default Mixin.create({
   init() {
-    this._super();
+    this._super(...arguments);
     this._relationshipTracker = Object.create(null);
   },
 

--- a/tests/integration/mixins/track-relationships-test.js
+++ b/tests/integration/mixins/track-relationships-test.js
@@ -1,6 +1,7 @@
 import Model, { hasMany, belongsTo, attr } from '@ember-data/model';
 import JSONAPISerializer from '@ember-data/serializer/json-api';
 import { run } from '@ember/runloop';
+import EmberObject from '@ember/object';
 import { resolve, all } from 'rsvp';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
@@ -415,5 +416,19 @@ module('Integration | Mixin | track relationships as Class', function(hooks) {
     }).then(pc => {
       assert.deepEqual(pc.map(c => c.get('body')), ["first post"]);
     });
+  });
+});
+
+module('Integration | Mixin | base class init receives args', function () {
+  test('it receives args', function (assert) {
+    let receivedArgs;
+    class ExampleModel extends EmberObject.extend(TrackRelationships) {
+      init() {
+        receivedArgs = arguments;
+      }
+    }
+    const model = new ExampleModel();
+    model.init(['a', 3]);
+    assert.deepEqual(receivedArgs, ['a', 3]);
   });
 });


### PR DESCRIPTION
On Ember Data 3.28, Model's init method [expects to receive arguments](https://github.com/emberjs/data/blob/8295458dba06eb7cf2c4354ea5f2484ecdfea3d7/packages/model/addon/-private/model.js#L122-L125) but they won't be there for models using the Ember Data Relationship Tracker mixin because it doesn't pass them along.